### PR TITLE
feat: implement persistent collection sorting per workspace and selected workspace memory

### DIFF
--- a/packages/coldbru-app/src/components/Sidebar/Sections/CollectionsSection/index.js
+++ b/packages/coldbru-app/src/components/Sidebar/Sections/CollectionsSection/index.js
@@ -171,6 +171,21 @@ const CollectionsSection = ({ collapsible = true, searchTrigger = 0 }) => {
         break;
     }
     dispatch(sortCollections({ order }));
+
+    // Save to preferences
+    const updatedPreferences = {
+      ...preferences,
+      collections: {
+        ...preferences.collections,
+        sortOrders: {
+          ...(preferences.collections?.sortOrders || {}),
+          [activeWorkspaceUid]: order
+        }
+      }
+    };
+    dispatch(savePreferences(updatedPreferences)).catch(() => {
+      toast.error('Failed to save sort preference');
+    });
   };
 
   const getSortIcon = () => {

--- a/packages/coldbru-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/coldbru-app/src/providers/ReduxStore/slices/collections/index.js
@@ -185,13 +185,27 @@ export const collectionsSlice = createSlice({
       // this is used in scenarios where we want to know the last action performed on the collection
       // and take some extra action based on that
       // for example, when a env is created, we want to auto select it the env modal
-      collection.importedAt = new Date().getTime();
+      collection.importedAt = performance.now();
       collection.lastAction = null;
 
       collapseAllItemsInCollection(collection);
       addDepth(collection.items);
       if (!hasExistingCollection) {
         state.collections.push(collection);
+
+        // Ensure collections remain sorted based on current preference
+        const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+        switch (state.collectionSortOrder) {
+          case 'default':
+            state.collections = state.collections.sort((a, b) => a.importedAt - b.importedAt);
+            break;
+          case 'alphabetical':
+            state.collections = state.collections.sort((a, b) => collator.compare(a.name, b.name));
+            break;
+          case 'reverseAlphabetical':
+            state.collections = state.collections.sort((a, b) => -collator.compare(a.name, b.name));
+            break;
+        }
       }
     },
     collapseFullCollection: (state, action) => {

--- a/packages/coldbru-app/src/providers/ReduxStore/slices/workspaces/actions.js
+++ b/packages/coldbru-app/src/providers/ReduxStore/slices/workspaces/actions.js
@@ -9,9 +9,9 @@ import {
   updateWorkspaceLoadingState,
   setWorkspaceScratchCollection
 } from '../workspaces';
-import { showHomePage } from '../app';
+import { removeCollection, addTransientDirectory, updateCollectionMountStatus, sortCollections } from '../collections';
+import { showHomePage, savePreferences } from '../app';
 import { createCollection, openCollection, openMultipleCollections, openScratchCollectionEvent } from '../collections/actions';
-import { removeCollection, addTransientDirectory, updateCollectionMountStatus } from '../collections';
 import { clearCollectionState } from '../openapi-sync';
 import { updateGlobalEnvironments } from '../global-environments';
 import { addTab, focusTab } from '../tabs';
@@ -244,7 +244,26 @@ export const switchWorkspace = (workspaceUid) => {
   return async (dispatch, getState) => {
     dispatch(setActiveWorkspace(workspaceUid));
 
-    const workspace = getState().workspaces.workspaces.find((w) => w.uid === workspaceUid);
+    const state = getState();
+    const preferences = state.app.preferences;
+    const prefActiveWorkspaceUid = preferences?.workspaces?.activeWorkspaceUid;
+
+    if (prefActiveWorkspaceUid !== workspaceUid) {
+      dispatch(
+        savePreferences({
+          ...preferences,
+          workspaces: {
+            ...preferences.workspaces,
+            activeWorkspaceUid: workspaceUid
+          }
+        })
+      );
+    }
+
+    const sortOrder = preferences?.collections?.sortOrders?.[workspaceUid] || 'default';
+    dispatch(sortCollections({ order: sortOrder }));
+
+    const workspace = state.workspaces.workspaces.find((w) => w.uid === workspaceUid);
 
     if (!workspace) {
       return;
@@ -270,12 +289,12 @@ export const switchWorkspace = (workspaceUid) => {
     const scratchCollection = await dispatch(mountScratchCollection(workspaceUid));
     await loadWorkspaceCollectionsForSwitch(dispatch, workspace);
 
-    const state = getState();
-    const requestTabView = state.requestTabView || { mode: 'home', collectionUid: null };
-    const activeWorkspace = state.workspaces.workspaces.find((w) => w.uid === workspaceUid);
-    const workspaceCollectionUids = getWorkspaceCollectionUids(state, activeWorkspace);
-    const tabs = state.tabs.tabs || [];
-    const activeTab = tabs.find((tab) => tab.uid === state.tabs.activeTabUid);
+    const currentState = getState();
+    const requestTabView = currentState.requestTabView || { mode: 'home', collectionUid: null };
+    const activeWorkspace = currentState.workspaces.workspaces.find((w) => w.uid === workspaceUid);
+    const workspaceCollectionUids = getWorkspaceCollectionUids(currentState, activeWorkspace);
+    const tabs = currentState.tabs.tabs || [];
+    const activeTab = tabs.find((tab) => tab.uid === currentState.tabs.activeTabUid);
     const overviewResult = getOverviewTabResult(scratchCollection?.uid || activeWorkspace?.scratchCollectionUid);
 
     const focusOverview = () => {
@@ -442,9 +461,12 @@ export const workspaceOpenedEvent = (workspacePath, workspaceUid, workspaceConfi
 
     const state = getState();
     const activeWorkspaceUid = state.workspaces.activeWorkspaceUid;
-    const activeWorkspace = state.workspaces.workspaces.find((workspace) => workspace.uid === activeWorkspaceUid);
+    const preferences = state.app.preferences;
+    const prefActiveWorkspaceUid = preferences?.workspaces?.activeWorkspaceUid;
 
-    if (!activeWorkspaceUid || !activeWorkspace) {
+    if (prefActiveWorkspaceUid === workspaceUid) {
+      dispatch(switchWorkspace(workspaceUid));
+    } else if (!activeWorkspaceUid && !prefActiveWorkspaceUid) {
       dispatch(switchWorkspace(workspaceUid));
     }
   };

--- a/packages/coldbru-electron/src/store/preferences.js
+++ b/packages/coldbru-electron/src/store/preferences.js
@@ -137,18 +137,18 @@ const preferencesSchema = Yup.object().shape({
   }),
   proxy: Yup.object({
     disabled: Yup.boolean().optional(),
-    inherit: Yup.boolean().required(),
+    inherit: Yup.boolean().optional(),
     config: Yup.object({
-      protocol: Yup.string().oneOf(['http', 'https', 'socks4', 'socks5']),
-      hostname: Yup.string().max(1024),
-      port: Yup.number().min(1).max(65535).nullable(),
+      protocol: Yup.string().oneOf(['http', 'https', 'socks4', 'socks5']).optional(),
+      hostname: Yup.string().max(1024).optional(),
+      port: Yup.number().min(1).max(65535).nullable().optional(),
       auth: Yup.object({
         disabled: Yup.boolean().optional(),
         username: Yup.string().max(1024),
         password: Yup.string().max(1024)
       }).optional(),
       bypassProxy: Yup.string().optional().max(1024)
-    }).required()
+    }).optional()
   }),
   layout: Yup.object({
     responsePaneOrientation: Yup.string().oneOf(['horizontal', 'vertical'])


### PR DESCRIPTION
### Description

Implemented UI state persistence for both the last opened **Workspace** and the User's preferred sort order for **Collections**, while keeping the sort order specific to a collection.

Fixes #15 

### Screenshots
<img width="1242" height="708" alt="Screenshot 2026-04-02 at 1 46 39 AM" src="https://github.com/user-attachments/assets/460d4638-689c-4339-ac3f-5b7dc5547aec" />

<img width="1242" height="708" alt="Screenshot 2026-04-02 at 1 48 53 AM" src="https://github.com/user-attachments/assets/e0e74a75-80bc-46b7-9aa8-f002e8c356b5" />
