### PR TITLE
fix: CodeMirror lag issue

### DIFF
--- a/packages/coldbru-app/src/utils/codemirror/shortcuts.js
+++ b/packages/coldbru-app/src/utils/codemirror/shortcuts.js
@@ -172,13 +172,14 @@ function buildKeymap(context) {
  * @param {Object} context - Context object containing props and other editor context
  * @returns {Object} Cleanup function to remove the keymap
  */
-function setupShortcuts(editor, context = {}) {
+function setupShortcuts(editor, context = {}, storeInstance = store) {
   if (!editor) {
     return () => { };
   }
 
   let currentKeyMap = null;
   let unsubscribeStore = null;
+  let previousKeyBindings = null;
 
   /**
    * Apply the consolidated custom keymap to the CodeMirror editor
@@ -202,9 +203,16 @@ function setupShortcuts(editor, context = {}) {
 
   // Apply keymap on setup
   applyKeyMap();
+  previousKeyBindings = storeInstance.getState()?.app?.preferences?.keyBindings;
 
   // Subscribe to store changes to rebuild keymap when preferences change
-  unsubscribeStore = store.subscribe(() => {
+  unsubscribeStore = storeInstance.subscribe(() => {
+    const nextKeyBindings = storeInstance.getState()?.app?.preferences?.keyBindings;
+    if (nextKeyBindings === previousKeyBindings) {
+      return;
+    }
+
+    previousKeyBindings = nextKeyBindings;
     applyKeyMap();
   });
 

--- a/packages/coldbru-app/src/utils/codemirror/shortcuts.spec.js
+++ b/packages/coldbru-app/src/utils/codemirror/shortcuts.spec.js
@@ -1,0 +1,95 @@
+const { describe, it, expect, jest, beforeEach, afterEach } = require('@jest/globals');
+
+jest.mock('codemirror', () => ({
+  Pass: 'CodeMirror.Pass'
+}));
+
+jest.mock('providers/Hotkeys/keyMappings', () => ({
+  getKeyBindingsForActionAllOS: jest.fn(() => [])
+}));
+
+jest.mock('providers/ReduxStore/slices/tabs', () => ({
+  reorderTabs: jest.fn((payload) => ({ type: 'tabs/reorderTabs', payload })),
+  switchTab: jest.fn((payload) => ({ type: 'tabs/switchTab', payload }))
+}));
+
+jest.mock('providers/ReduxStore/slices/app', () => ({
+  savePreferences: jest.fn((payload) => ({ type: 'app/savePreferences', payload })),
+  toggleSidebarCollapse: jest.fn(() => ({ type: 'app/toggleSidebarCollapse' }))
+}));
+
+import { setupShortcuts } from './shortcuts';
+
+describe('setupShortcuts', () => {
+  let editor;
+  let mockStore;
+  let state;
+  let listener;
+  let unsubscribe;
+
+  beforeEach(() => {
+    editor = {
+      addKeyMap: jest.fn(),
+      removeKeyMap: jest.fn()
+    };
+
+    listener = null;
+    unsubscribe = jest.fn();
+    state = {
+      app: {
+        preferences: {
+          keyBindings: {
+            sendRequest: ['command+enter']
+          }
+        }
+      }
+    };
+
+    mockStore = {
+      dispatch: jest.fn(),
+      getState: jest.fn(() => state),
+      subscribe: jest.fn((cb) => {
+        listener = cb;
+        return unsubscribe;
+      })
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not rebuild keymap when store updates without keybinding changes', () => {
+    const cleanup = setupShortcuts(editor, {}, mockStore);
+
+    expect(editor.addKeyMap).toHaveBeenCalledTimes(1);
+    expect(typeof listener).toBe('function');
+
+    listener();
+
+    expect(editor.removeKeyMap).not.toHaveBeenCalled();
+    expect(editor.addKeyMap).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('rebuilds keymap when keybindings reference changes', () => {
+    setupShortcuts(editor, {}, mockStore);
+
+    state = {
+      app: {
+        preferences: {
+          keyBindings: {
+            sendRequest: ['ctrl+enter']
+          }
+        }
+      }
+    };
+
+    expect(typeof listener).toBe('function');
+    listener();
+
+    expect(editor.removeKeyMap).toHaveBeenCalledTimes(1);
+    expect(editor.addKeyMap).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
### Description

Fix shortcuts.js: editor shortcuts now rebuild only when preferences.keyBindings actually changes, not on every Redux update while typing.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/nicandcranny/coldbru/blob/main/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.
