### PR TITLE
Add command palette and streamline environment navigation

### DIFF
--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -30,6 +30,7 @@ Low-level, generic building blocks. Use these first.
 | Portal | `components/Portal` | Renders children into `document.body` via React portal. |
 | ErrorCapture | `components/ErrorCapture` | React error boundary + global `console.error` interceptor that dispatches to Redux debug log. |
 | Notifications | `components/Notifications` | Bell icon with unread badge, opens paginated notifications modal. No props (uses Redux internally). |
+| CommandPaletteModal | `components/CommandPaletteModal` | Keyboard-first action launcher opened from `Cmd/Ctrl+Shift+P`, with fuzzy command filtering and arrow-key navigation. Props: `isOpen`, `onClose`. |
 
 ### Form Controls
 

--- a/README.md
+++ b/README.md
@@ -139,3 +139,4 @@ ColdBru is released under the [MIT License](LICENSE.md).
 - Arrow button to select after search on environment list
 - Arrow button to move between requests
 - Add go to file feature in the Git menu
+- Import Postman's export

--- a/README.md
+++ b/README.md
@@ -136,7 +136,5 @@ ColdBru is released under the [MIT License](LICENSE.md).
 ## Future Improvements
 
 - Instant action (like Cmd+Shift+P) - for git, etc.
-- Arrow button to select after search on environment list
-- Arrow button to move between requests
-- Add go to file feature in the Git menu
+- Add go to request/environment feature in the Git menu
 - Import Postman's export

--- a/README.md
+++ b/README.md
@@ -135,6 +135,6 @@ ColdBru is released under the [MIT License](LICENSE.md).
 
 ## Future Improvements
 
-- Instant action (like Cmd+Shift+P) - for git, etc.
+- Add more to instant action (like Cmd+Shift+P) - for git, etc.
 - Add go to request/environment feature in the Git menu
 - Import Postman's export

--- a/README.md
+++ b/README.md
@@ -135,9 +135,7 @@ ColdBru is released under the [MIT License](LICENSE.md).
 
 ## Future Improvements
 
-- Import environment feature
 - Instant action (like Cmd+Shift+P) - for git, etc.
-- Add send to top and send to bottom button in collections list
 - Arrow button to select after search on environment list
 - Arrow button to move between requests
 - Add go to file feature in the Git menu

--- a/package-lock.json
+++ b/package-lock.json
@@ -870,10 +870,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -882,7 +884,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -917,11 +921,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -931,21 +937,25 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.27.3",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -955,15 +965,17 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-member-expression-to-functions": "^7.28.5",
-        "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/helper-replace-supers": "^7.28.6",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.28.6",
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -974,11 +986,13 @@
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.28.5",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-annotate-as-pure": "^7.29.7",
         "regexpu-core": "^6.3.1",
         "semver": "^6.3.1"
       },
@@ -1005,41 +1019,49 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.28.5",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1049,30 +1071,36 @@
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.1"
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.29.7.tgz",
+      "integrity": "sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
-        "@babel/helper-wrap-function": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-wrap-function": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1082,12 +1110,14 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.28.5",
-        "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1097,45 +1127,55 @@
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.29.7.tgz",
+      "integrity": "sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1153,10 +1193,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1166,11 +1208,13 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.29.7.tgz",
+      "integrity": "sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1180,11 +1224,13 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.29.7.tgz",
+      "integrity": "sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1194,13 +1240,15 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.29.7.tgz",
+      "integrity": "sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/plugin-transform-optional-chaining": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/plugin-transform-optional-chaining": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1281,11 +1329,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1452,11 +1502,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.29.7.tgz",
+      "integrity": "sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1466,11 +1518,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.29.7.tgz",
+      "integrity": "sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1480,11 +1534,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-properties": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz",
+      "integrity": "sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1494,11 +1550,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.29.7.tgz",
+      "integrity": "sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1508,11 +1566,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-dynamic-import": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.29.7.tgz",
+      "integrity": "sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1522,11 +1582,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-export-namespace-from": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.29.7.tgz",
+      "integrity": "sha512-24B2nOy2TeJSMheqwPD4DDQOV/elLSIlKxjZt4i05H5AgdPdWR3n18HnNrcJ+j76WJd9gbwb9jPjNYUy6RautA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1550,12 +1612,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.29.7.tgz",
+      "integrity": "sha512-zeSIHh0+E1Um1WJRXCFlHQYu2ieJNdivLLjlBEp+dIBu3S51n+SZZmIXjxnItw6pz56Cn+KvK68BIBVsxq2JiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1565,13 +1629,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-function-name": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.29.7.tgz",
+      "integrity": "sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1581,11 +1647,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-literals": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.29.7.tgz",
+      "integrity": "sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1595,11 +1663,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.29.7.tgz",
+      "integrity": "sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1609,12 +1679,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-amd": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.29.7.tgz",
+      "integrity": "sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1624,11 +1696,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
+      "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1638,12 +1712,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.29.7.tgz",
+      "integrity": "sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1653,11 +1729,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-new-target": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.29.7.tgz",
+      "integrity": "sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1667,10 +1745,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.29.7.tgz",
+      "integrity": "sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1680,12 +1760,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-super": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.29.7.tgz",
+      "integrity": "sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-replace-supers": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1695,11 +1777,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.29.7.tgz",
+      "integrity": "sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1709,11 +1793,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-methods": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.29.7.tgz",
+      "integrity": "sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1723,11 +1809,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-property-literals": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.29.7.tgz",
+      "integrity": "sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1784,11 +1872,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-reserved-words": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.29.7.tgz",
+      "integrity": "sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1798,11 +1888,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.29.7.tgz",
+      "integrity": "sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1812,11 +1904,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-sticky-regex": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.29.7.tgz",
+      "integrity": "sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1826,11 +1920,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-template-literals": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.29.7.tgz",
+      "integrity": "sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1840,11 +1936,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.29.7.tgz",
+      "integrity": "sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1871,11 +1969,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.29.7.tgz",
+      "integrity": "sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1885,12 +1985,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-regex": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.29.7.tgz",
+      "integrity": "sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2004,27 +2106,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -2032,11 +2138,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"

--- a/packages/coldbru-app/src/components/CodeEditor/index.js
+++ b/packages/coldbru-app/src/components/CodeEditor/index.js
@@ -243,8 +243,9 @@ export default class CodeEditor extends React.Component {
       // TODO: temporary fix for keeping cursor state when auto save and new line insertion collide PR#7098
       const nextValue = this.props.value ?? '';
       const currentValue = this.editor.getValue();
+      const shouldSyncWhileFocused = Boolean(this.props.syncValueWhileFocused);
       // Skip updating only when focused and editable; read-only editors (e.g. response viewer) must always show new value
-      if (this.editor.hasFocus?.() && currentValue !== nextValue && !this.props.readOnly) {
+      if (this.editor.hasFocus?.() && currentValue !== nextValue && !this.props.readOnly && !shouldSyncWhileFocused) {
         this.cachedValue = currentValue;
       } else {
         const cursor = this.editor.getCursor();

--- a/packages/coldbru-app/src/components/CommandPaletteModal/StyledWrapper.js
+++ b/packages/coldbru-app/src/components/CommandPaletteModal/StyledWrapper.js
@@ -1,0 +1,127 @@
+import styled from 'styled-components';
+
+const StyledWrapper = styled.div`
+  .command-palette-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 30;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 4rem 1rem 1rem;
+    background: rgba(0, 0, 0, ${(props) => props.theme.modal.backdrop.opacity});
+  }
+
+  .command-palette-modal {
+    width: min(38rem, 100%);
+    max-height: 70vh;
+    display: flex;
+    flex-direction: column;
+    background: ${(props) => props.theme.modal.body.bg};
+    border: 1px solid ${(props) => props.theme.border.border1};
+    border-radius: 0.75rem;
+    box-shadow: ${(props) => props.theme.shadow.lg};
+    overflow: hidden;
+  }
+
+  .command-palette-header {
+    padding: 1rem;
+    border-bottom: 1px solid ${(props) => props.theme.border.border1};
+  }
+
+  .command-palette-title-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+    color: ${(props) => props.theme.text};
+
+    h1 {
+      margin: 0;
+      font-size: ${(props) => props.theme.font.size.base};
+    }
+  }
+
+  .command-palette-search {
+    position: relative;
+
+    .search-icon {
+      position: absolute;
+      top: 50%;
+      left: 0.75rem;
+      transform: translateY(-50%);
+      color: ${(props) => props.theme.colors.text.muted};
+      pointer-events: none;
+    }
+
+    input {
+      width: 100%;
+      padding: 0.65rem 0.75rem 0.65rem 2.25rem;
+      background: transparent;
+      border: 1px solid ${(props) => props.theme.input.border};
+      border-radius: ${(props) => props.theme.border.radius.base};
+      color: ${(props) => props.theme.text};
+      font-size: ${(props) => props.theme.font.size.base};
+
+      &:focus {
+        outline: none;
+        border-color: ${(props) => props.theme.input.focusBorder};
+      }
+    }
+  }
+
+  .command-palette-results {
+    overflow-y: auto;
+    padding: 0.5rem;
+  }
+
+  .command-item {
+    width: 100%;
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.75rem;
+    text-align: left;
+    background: transparent;
+    border: none;
+    border-radius: ${(props) => props.theme.border.radius.base};
+    color: ${(props) => props.theme.text};
+    cursor: pointer;
+
+    &:hover,
+    &.selected {
+      background: ${(props) => props.theme.dropdown.hoverBg};
+    }
+  }
+
+  .command-item-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: ${(props) => props.theme.colors.text.muted};
+  }
+
+  .command-item-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+  }
+
+  .command-item-title {
+    font-size: ${(props) => props.theme.font.size.base};
+  }
+
+  .command-item-description {
+    color: ${(props) => props.theme.colors.text.muted};
+    font-size: ${(props) => props.theme.font.size.sm};
+  }
+
+  .command-palette-empty {
+    padding: 1rem;
+    color: ${(props) => props.theme.colors.text.muted};
+    font-size: ${(props) => props.theme.font.size.sm};
+  }
+`;
+
+export default StyledWrapper;

--- a/packages/coldbru-app/src/components/CommandPaletteModal/index.js
+++ b/packages/coldbru-app/src/components/CommandPaletteModal/index.js
@@ -1,0 +1,253 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { IconCommand, IconSearch, IconSettings, IconPlus, IconUpload, IconVariable } from '@tabler/icons';
+import { useDispatch, useSelector } from 'react-redux';
+import Portal from 'components/Portal';
+import { addTab } from 'providers/ReduxStore/slices/tabs';
+import StyledWrapper from './StyledWrapper';
+
+const COMMANDS = [
+  {
+    id: 'open-collection-environment-picker',
+    title: 'Open Collection Environment Picker',
+    description: 'Open existing collection environment dropdown.',
+    keywords: ['env', 'environment', 'switch', 'collection', 'variables'],
+    icon: IconVariable,
+    run: () => {
+      window.dispatchEvent(new CustomEvent('environment-selector-open', {
+        detail: {
+          preferredTab: 'collection'
+        }
+      }));
+    }
+  },
+  {
+    id: 'open-global-environment-picker',
+    title: 'Open Global Environment Picker',
+    description: 'Open existing global environment dropdown.',
+    keywords: ['env', 'environment', 'switch', 'global', 'variables'],
+    icon: IconVariable,
+    run: () => {
+      window.dispatchEvent(new CustomEvent('environment-selector-open', {
+        detail: {
+          preferredTab: 'global'
+        }
+      }));
+    }
+  },
+  {
+    id: 'open-global-search',
+    title: 'Open Global Search',
+    description: 'Search collections, requests, environments, and API specs.',
+    keywords: ['search', 'find', 'request', 'collection', 'spec'],
+    icon: IconSearch,
+    run: () => {
+      window.dispatchEvent(new CustomEvent('global-search-open'));
+    }
+  },
+  {
+    id: 'new-request',
+    title: 'New Request',
+    description: 'Create request in current collection.',
+    keywords: ['request', 'new', 'create', 'api'],
+    icon: IconPlus,
+    run: () => {
+      window.dispatchEvent(new CustomEvent('new-request-open'));
+    }
+  },
+  {
+    id: 'import-collection',
+    title: 'Import Collection',
+    description: 'Import Postman, OpenAPI, Insomnia, or Bruno files.',
+    keywords: ['import', 'collection', 'postman', 'openapi', 'insomnia'],
+    icon: IconUpload,
+    run: () => {
+      window.dispatchEvent(new CustomEvent('import-collection-open'));
+    }
+  }
+];
+
+const CommandPaletteModal = ({ isOpen, onClose }) => {
+  const dispatch = useDispatch();
+  const tabs = useSelector((state) => state.tabs.tabs);
+  const activeTabUid = useSelector((state) => state.tabs.activeTabUid);
+  const workspaces = useSelector((state) => state.workspaces.workspaces);
+  const activeWorkspaceUid = useSelector((state) => state.workspaces.activeWorkspaceUid);
+
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef(null);
+  const resultsRef = useRef(null);
+
+  const activeWorkspace = workspaces.find((workspace) => workspace.uid === activeWorkspaceUid) || null;
+  const activeTab = tabs.find((tab) => tab.uid === activeTabUid) || null;
+  const preferenceCollectionUid = activeTab?.collectionUid || activeWorkspace?.scratchCollectionUid || null;
+
+  const commands = useMemo(() => {
+    return [
+      ...COMMANDS,
+      {
+        id: 'open-preferences',
+        title: 'Open Preferences',
+        description: 'Manage keybindings, themes, and app settings.',
+        keywords: ['preferences', 'settings', 'config', 'keybindings'],
+        icon: IconSettings,
+        run: () => {
+          dispatch(addTab({
+            type: 'preferences',
+            uid: preferenceCollectionUid ? `${preferenceCollectionUid}-preferences` : 'preferences',
+            collectionUid: preferenceCollectionUid
+          }));
+        }
+      }
+    ];
+  }, [dispatch, preferenceCollectionUid]);
+
+  const filteredCommands = useMemo(() => {
+    const searchTerms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+
+    if (!searchTerms.length) {
+      return commands;
+    }
+
+    return commands.filter((command) => {
+      const haystack = `${command.title} ${command.description} ${(command.keywords || []).join(' ')}`.toLowerCase();
+      return searchTerms.every((term) => haystack.includes(term));
+    });
+  }, [commands, query]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setQuery('');
+    setSelectedIndex(0);
+
+    const timeoutId = setTimeout(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select?.();
+    }, 0);
+
+    return () => clearTimeout(timeoutId);
+  }, [isOpen]);
+
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  useEffect(() => {
+    if (!filteredCommands.length || !resultsRef.current) {
+      return;
+    }
+
+    resultsRef.current.children[selectedIndex]?.scrollIntoView({
+      block: 'nearest'
+    });
+  }, [filteredCommands.length, selectedIndex]);
+
+  const runCommand = (command) => {
+    if (!command) {
+      return;
+    }
+
+    onClose();
+    command.run();
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setSelectedIndex((current) => (current < filteredCommands.length - 1 ? current + 1 : 0));
+      return;
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setSelectedIndex((current) => (current > 0 ? current - 1 : filteredCommands.length - 1));
+      return;
+    }
+
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      runCommand(filteredCommands[selectedIndex]);
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onClose();
+    }
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Portal>
+      <StyledWrapper>
+        <div className="command-palette-overlay" onClick={onClose}>
+          <div
+            className="command-palette-modal"
+            onClick={(event) => event.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="command-palette-title"
+          >
+            <div className="command-palette-header">
+              <div className="command-palette-title-row">
+                <IconCommand size={18} strokeWidth={1.5} />
+                <h1 id="command-palette-title">Command Palette</h1>
+              </div>
+              <div className="command-palette-search">
+                <IconSearch size={16} strokeWidth={1.5} className="search-icon" />
+                <input
+                  ref={inputRef}
+                  type="text"
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Type command name..."
+                  aria-label="Command palette search"
+                />
+              </div>
+            </div>
+
+            <div className="command-palette-results" ref={resultsRef} role="listbox" aria-label="Command results">
+              {filteredCommands.length ? (
+                filteredCommands.map((command, index) => {
+                  const Icon = command.icon;
+
+                  return (
+                    <button
+                      key={command.id}
+                      className={`command-item ${index === selectedIndex ? 'selected' : ''}`}
+                      onClick={() => runCommand(command)}
+                      onMouseEnter={() => setSelectedIndex(index)}
+                      role="option"
+                      aria-selected={index === selectedIndex}
+                    >
+                      <span className="command-item-icon">
+                        <Icon size={18} strokeWidth={1.5} />
+                      </span>
+                      <span className="command-item-copy">
+                        <span className="command-item-title">{command.title}</span>
+                        <span className="command-item-description">{command.description}</span>
+                      </span>
+                    </button>
+                  );
+                })
+              ) : (
+                <div className="command-palette-empty">
+                  No commands found for "{query}".
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </StyledWrapper>
+    </Portal>
+  );
+};
+
+export default CommandPaletteModal;

--- a/packages/coldbru-app/src/components/Environments/EnvironmentSelector/EnvironmentListContent/index.js
+++ b/packages/coldbru-app/src/components/Environments/EnvironmentSelector/EnvironmentListContent/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { IconPlus, IconDownload, IconSettings, IconSearch, IconX } from '@tabler/icons';
 import ToolHint from 'components/ToolHint';
 import ColorBadge from 'components/ColorBadge';
@@ -10,11 +10,134 @@ const EnvironmentListContent = ({
   description,
   searchText,
   setSearchText,
+  isOpen,
   onEnvironmentSelect,
   onSettingsClick,
   onCreateClick,
-  onImportClick
+  onImportClick,
+  onClose
 }) => {
+  const optionRefs = useRef([]);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+
+  const selectableOptions = useMemo(() => {
+    const environmentOptions = environments.map((env) => ({
+      id: env.uid,
+      type: 'environment',
+      environment: env
+    }));
+
+    return [
+      {
+        id: 'no-environment',
+        type: 'none'
+      },
+      ...environmentOptions,
+      {
+        id: 'configure',
+        type: 'configure'
+      }
+    ];
+  }, [environments]);
+
+  const navigableIndices = useMemo(() => {
+    if (searchText.trim()) {
+      return environments.map((_, index) => index + 1);
+    }
+
+    return selectableOptions.map((_, index) => index);
+  }, [environments, searchText, selectableOptions]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setHighlightedIndex(-1);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    setHighlightedIndex(-1);
+  }, [searchText, environments]);
+
+  useEffect(() => {
+    if (highlightedIndex < 0) {
+      return;
+    }
+
+    optionRefs.current[highlightedIndex]?.scrollIntoView?.({ block: 'nearest' });
+  }, [highlightedIndex]);
+
+  const moveHighlight = (direction) => {
+    if (!navigableIndices.length) {
+      return;
+    }
+
+    setHighlightedIndex((currentIndex) => {
+      const currentNavigableIndex = navigableIndices.indexOf(currentIndex);
+
+      if (currentNavigableIndex < 0) {
+        return direction === 1 ? navigableIndices[0] : navigableIndices[navigableIndices.length - 1];
+      }
+
+      const nextNavigableIndex = (currentNavigableIndex + direction + navigableIndices.length) % navigableIndices.length;
+      return navigableIndices[nextNavigableIndex];
+    });
+  };
+
+  const activateHighlightedOption = () => {
+    if (highlightedIndex < 0) {
+      return;
+    }
+
+    const option = selectableOptions[highlightedIndex];
+
+    if (option?.type === 'none') {
+      onEnvironmentSelect(null);
+      return;
+    }
+
+    if (option?.type === 'environment') {
+      onEnvironmentSelect(option.environment);
+      return;
+    }
+
+    if (option?.type === 'configure') {
+      onSettingsClick();
+    }
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      moveHighlight(1);
+      return;
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      moveHighlight(-1);
+      return;
+    }
+
+    if (event.key === 'Enter') {
+      if (highlightedIndex >= 0) {
+        event.preventDefault();
+        activateHighlightedOption();
+      }
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onClose?.();
+    }
+  };
+
+  const getOptionClassName = (index, isActive = false) => {
+    return `dropdown-item ${isActive ? 'dropdown-item-active' : ''} ${highlightedIndex === index ? 'dropdown-item-focused' : ''}`.trim();
+  };
+
+  const getOptionId = (id) => `environment-option-${id}`;
+
   return (
     <div>
       {hasEnvironments ? (
@@ -31,6 +154,11 @@ const EnvironmentListContent = ({
               autoCorrect="off"
               autoCapitalize="off"
               spellCheck="false"
+              onKeyDown={handleKeyDown}
+              role="combobox"
+              aria-expanded={isOpen}
+              aria-controls="environment-selector-listbox"
+              aria-activedescendant={highlightedIndex >= 0 ? getOptionId(selectableOptions[highlightedIndex]?.id) : undefined}
             />
             {searchText ? (
               <button
@@ -43,8 +171,24 @@ const EnvironmentListContent = ({
               </button>
             ) : null}
           </div>
-          <div className="environment-list">
-            <div className="dropdown-item no-environment" onClick={() => onEnvironmentSelect(null)}>
+          <div
+            className="environment-list"
+            role="listbox"
+            id="environment-selector-listbox"
+            aria-label="Environment options"
+            onKeyDown={handleKeyDown}
+          >
+            <div
+              ref={(node) => {
+                optionRefs.current[0] = node;
+              }}
+              id={getOptionId('no-environment')}
+              className={getOptionClassName(0, !activeEnvironmentUid)}
+              onClick={() => onEnvironmentSelect(null)}
+              onMouseEnter={() => setHighlightedIndex(0)}
+              role="option"
+              aria-selected={!activeEnvironmentUid}
+            >
               <span>No Environment</span>
             </div>
             <ToolHint
@@ -59,13 +203,20 @@ const EnvironmentListContent = ({
             >
               <div>
                 {environments.length ? (
-                  environments.map((env) => (
+                  environments.map((env, index) => (
                     <div
                       key={env.uid}
-                      className={`dropdown-item ${env.uid === activeEnvironmentUid ? 'dropdown-item-active' : ''}`}
+                      ref={(node) => {
+                        optionRefs.current[index + 1] = node;
+                      }}
+                      id={getOptionId(env.uid)}
+                      className={getOptionClassName(index + 1, env.uid === activeEnvironmentUid)}
                       onClick={() => onEnvironmentSelect(env)}
+                      onMouseEnter={() => setHighlightedIndex(index + 1)}
                       data-tooltip-content={env.name}
                       data-tooltip-hidden={env.name?.length < 90}
+                      role="option"
+                      aria-selected={env.uid === activeEnvironmentUid}
                     >
                       <ColorBadge color={env.color} size={8} />
                       <span className="max-w-100% truncate no-wrap">{env.name}</span>
@@ -76,11 +227,19 @@ const EnvironmentListContent = ({
                 )}
               </div>
             </ToolHint>
-            <div className="dropdown-item configure-button">
-              <button onClick={onSettingsClick} id="configure-env">
-                <IconSettings size={16} strokeWidth={1.5} />
-                <span>Configure</span>
-              </button>
+            <div
+              ref={(node) => {
+                optionRefs.current[selectableOptions.length - 1] = node;
+              }}
+              id={getOptionId('configure')}
+              className={`${getOptionClassName(selectableOptions.length - 1)} configure-button`}
+              onClick={onSettingsClick}
+              onMouseEnter={() => setHighlightedIndex(selectableOptions.length - 1)}
+              role="option"
+              aria-selected={false}
+            >
+              <IconSettings size={16} strokeWidth={1.5} />
+              <span>Configure</span>
             </div>
           </div>
         </>

--- a/packages/coldbru-app/src/components/Environments/EnvironmentSelector/EnvironmentListContent/index.js
+++ b/packages/coldbru-app/src/components/Environments/EnvironmentSelector/EnvironmentListContent/index.js
@@ -11,6 +11,7 @@ const EnvironmentListContent = ({
   searchText,
   setSearchText,
   isOpen,
+  autoFocusSearch = false,
   onEnvironmentSelect,
   onSettingsClick,
   onCreateClick,
@@ -18,6 +19,7 @@ const EnvironmentListContent = ({
   onClose
 }) => {
   const optionRefs = useRef([]);
+  const inputRef = useRef(null);
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
 
   const selectableOptions = useMemo(() => {
@@ -53,6 +55,15 @@ const EnvironmentListContent = ({
       setHighlightedIndex(-1);
     }
   }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || !autoFocusSearch || !hasEnvironments) {
+      return;
+    }
+
+    inputRef.current?.focus();
+    inputRef.current?.select?.();
+  }, [autoFocusSearch, hasEnvironments, isOpen]);
 
   useEffect(() => {
     setHighlightedIndex(-1);
@@ -145,6 +156,7 @@ const EnvironmentListContent = ({
           <div className="environment-search">
             <IconSearch size={13} strokeWidth={1.5} className="environment-search-icon" />
             <input
+              ref={inputRef}
               type="text"
               placeholder="Search environments..."
               value={searchText}

--- a/packages/coldbru-app/src/components/Environments/EnvironmentSelector/EnvironmentListContent/index.spec.js
+++ b/packages/coldbru-app/src/components/Environments/EnvironmentSelector/EnvironmentListContent/index.spec.js
@@ -42,6 +42,14 @@ const renderComponent = (props = {}) => {
 };
 
 describe('EnvironmentListContent keyboard navigation', () => {
+  it('autofocuses search input when requested', () => {
+    renderComponent({
+      autoFocusSearch: true
+    });
+
+    expect(screen.getByPlaceholderText('Search environments...')).toHaveFocus();
+  });
+
   it('selects first matching environment with ArrowDown then Enter while searching', () => {
     const props = renderComponent({
       environments: [{ uid: 'env-1', name: 'Development', color: '#00ff00' }],

--- a/packages/coldbru-app/src/components/Environments/EnvironmentSelector/EnvironmentListContent/index.spec.js
+++ b/packages/coldbru-app/src/components/Environments/EnvironmentSelector/EnvironmentListContent/index.spec.js
@@ -1,0 +1,93 @@
+require('@testing-library/jest-dom');
+
+const React = require('react');
+const { fireEvent, render, screen } = require('@testing-library/react');
+
+jest.mock('components/ToolHint', () => ({ children }) => {
+  const mockReact = require('react');
+  return mockReact.createElement(mockReact.Fragment, null, children);
+});
+
+jest.mock('components/ColorBadge', () => () => {
+  const mockReact = require('react');
+  return mockReact.createElement('span', { 'data-testid': 'color-badge' });
+});
+
+const EnvironmentListContent = require('./index').default;
+
+const renderComponent = (props = {}) => {
+  const defaultProps = {
+    environments: [
+      { uid: 'env-1', name: 'Development', color: '#00ff00' },
+      { uid: 'env-2', name: 'Staging', color: '#ffaa00' }
+    ],
+    hasEnvironments: true,
+    activeEnvironmentUid: 'env-2',
+    description: 'Create one',
+    searchText: '',
+    setSearchText: jest.fn(),
+    isOpen: true,
+    onEnvironmentSelect: jest.fn(),
+    onSettingsClick: jest.fn(),
+    onCreateClick: jest.fn(),
+    onImportClick: jest.fn(),
+    onClose: jest.fn()
+  };
+
+  const allProps = { ...defaultProps, ...props };
+
+  render(React.createElement(EnvironmentListContent, allProps));
+
+  return allProps;
+};
+
+describe('EnvironmentListContent keyboard navigation', () => {
+  it('selects first matching environment with ArrowDown then Enter while searching', () => {
+    const props = renderComponent({
+      environments: [{ uid: 'env-1', name: 'Development', color: '#00ff00' }],
+      searchText: 'dev'
+    });
+
+    const searchInput = screen.getByPlaceholderText('Search environments...');
+
+    fireEvent.keyDown(searchInput, { key: 'ArrowDown' });
+    fireEvent.keyDown(searchInput, { key: 'Enter' });
+
+    expect(props.onEnvironmentSelect).toHaveBeenCalledWith({
+      uid: 'env-1',
+      name: 'Development',
+      color: '#00ff00'
+    });
+  });
+
+  it('cycles through default options and can activate no environment', () => {
+    const props = renderComponent();
+    const searchInput = screen.getByPlaceholderText('Search environments...');
+
+    fireEvent.keyDown(searchInput, { key: 'ArrowDown' });
+    fireEvent.keyDown(searchInput, { key: 'Enter' });
+
+    expect(props.onEnvironmentSelect).toHaveBeenCalledWith(null);
+  });
+
+  it('wraps navigation to configure and triggers settings', () => {
+    const props = renderComponent({
+      environments: [{ uid: 'env-1', name: 'Development', color: '#00ff00' }]
+    });
+    const searchInput = screen.getByPlaceholderText('Search environments...');
+
+    fireEvent.keyDown(searchInput, { key: 'ArrowUp' });
+    fireEvent.keyDown(searchInput, { key: 'Enter' });
+
+    expect(props.onSettingsClick).toHaveBeenCalled();
+  });
+
+  it('closes on Escape', () => {
+    const props = renderComponent();
+    const searchInput = screen.getByPlaceholderText('Search environments...');
+
+    fireEvent.keyDown(searchInput, { key: 'Escape' });
+
+    expect(props.onClose).toHaveBeenCalled();
+  });
+});

--- a/packages/coldbru-app/src/components/Environments/EnvironmentSelector/StyledWrapper.js
+++ b/packages/coldbru-app/src/components/Environments/EnvironmentSelector/StyledWrapper.js
@@ -92,18 +92,14 @@ const Wrapper = styled.div`
     border-top: 0.0625rem solid ${(props) => props.theme.dropdown.separator};
     z-index: 10;
     margin: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    color: ${(props) => props.theme.text};
 
     &:hover {
       background-color: ${(props) => props.theme.dropdown.bg + ' !important'};
-    }
-
-    button {
-      color: ${(props) => props.theme.text};
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 100%;
-      gap: 0.5rem;
     }
   }
 

--- a/packages/coldbru-app/src/components/Environments/EnvironmentSelector/index.js
+++ b/packages/coldbru-app/src/components/Environments/EnvironmentSelector/index.js
@@ -207,6 +207,33 @@ const EnvironmentSelector = ({ collection, showCollectionEnv = true }) => {
     }
   }, [activeTab, safeCollection.uid, showCollectionEnv]);
 
+  useEffect(() => {
+    const handleOpenEnvironmentSelector = (event) => {
+      const preferredTab = event?.detail?.preferredTab;
+
+      if (preferredTab === 'collection' && (!showCollectionEnv || !safeCollection.uid)) {
+        toast.error('Collection environments are not available in current view');
+        return;
+      }
+
+      if (preferredTab === 'collection' || preferredTab === 'global') {
+        setActiveTab(preferredTab);
+      }
+
+      setSearchText('');
+
+      window.requestAnimationFrame(() => {
+        dropdownTippyRef.current?.show();
+      });
+    };
+
+    window.addEventListener('environment-selector-open', handleOpenEnvironmentSelector);
+
+    return () => {
+      window.removeEventListener('environment-selector-open', handleOpenEnvironmentSelector);
+    };
+  }, [safeCollection.uid, showCollectionEnv]);
+
   const hideDropdown = () => {
     dropdownTippyRef.current?.hide();
   };
@@ -358,6 +385,7 @@ const EnvironmentSelector = ({ collection, showCollectionEnv = true }) => {
               searchText={searchText}
               setSearchText={setSearchText}
               isOpen={isDropdownOpen}
+              autoFocusSearch={isDropdownOpen}
               onEnvironmentSelect={handleEnvironmentSelect}
               onSettingsClick={handleSettingsClick}
               onCreateClick={handleCreateClick}

--- a/packages/coldbru-app/src/components/Environments/EnvironmentSelector/index.js
+++ b/packages/coldbru-app/src/components/Environments/EnvironmentSelector/index.js
@@ -155,6 +155,7 @@ const EnvironmentSelector = ({ collection, showCollectionEnv = true }) => {
   const [showCreateCollectionModal, setShowCreateCollectionModal] = useState(false);
   const [showImportCollectionModal, setShowImportCollectionModal] = useState(false);
   const [searchText, setSearchText] = useState('');
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const workspaces = useSelector((state) => state.workspaces.workspaces);
   const activeWorkspaceUid = useSelector((state) => state.workspaces.activeWorkspaceUid);
@@ -207,7 +208,6 @@ const EnvironmentSelector = ({ collection, showCollectionEnv = true }) => {
   }, [activeTab, safeCollection.uid, showCollectionEnv]);
 
   const hideDropdown = () => {
-    setSearchText('');
     dropdownTippyRef.current?.hide();
   };
 
@@ -323,6 +323,11 @@ const EnvironmentSelector = ({ collection, showCollectionEnv = true }) => {
             />
           )}
           placement="bottom-end"
+          onShow={() => setIsDropdownOpen(true)}
+          onHide={() => {
+            setIsDropdownOpen(false);
+            setSearchText('');
+          }}
         >
           {/* Tab Headers */}
           <div className="tab-header flex pt-3 pb-2 px-3">
@@ -352,10 +357,12 @@ const EnvironmentSelector = ({ collection, showCollectionEnv = true }) => {
               description={description}
               searchText={searchText}
               setSearchText={setSearchText}
+              isOpen={isDropdownOpen}
               onEnvironmentSelect={handleEnvironmentSelect}
               onSettingsClick={handleSettingsClick}
               onCreateClick={handleCreateClick}
               onImportClick={handleImportClick}
+              onClose={hideDropdown}
             />
           </div>
         </Dropdown>

--- a/packages/coldbru-app/src/components/RequestPane/GraphQLVariables/index.js
+++ b/packages/coldbru-app/src/components/RequestPane/GraphQLVariables/index.js
@@ -66,6 +66,8 @@ const GraphQLVariables = ({ variables, item, collection }) => {
         mode="application/json"
         onRun={onRun}
         onSave={onSave}
+        onPrettify={onPrettify}
+        syncValueWhileFocused={true}
         enableVariableHighlighting={true}
         showHintsFor={['variables']}
       />

--- a/packages/coldbru-app/src/components/RequestPane/GrpcBody/index.js
+++ b/packages/coldbru-app/src/components/RequestPane/GrpcBody/index.js
@@ -207,6 +207,8 @@ const SingleGrpcMessage = ({ message, item, collection, index, methodType, handl
           onEdit={onEdit}
           onRun={handleRun}
           onSave={onSave}
+          onPrettify={onPrettify}
+          syncValueWhileFocused={true}
           mode="application/ld+json"
           enableVariableHighlighting={true}
         />

--- a/packages/coldbru-app/src/components/RequestPane/RequestBody/index.js
+++ b/packages/coldbru-app/src/components/RequestPane/RequestBody/index.js
@@ -11,6 +11,8 @@ import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collection
 import { updateRequestBodyScrollPosition } from 'providers/ReduxStore/slices/tabs';
 import StyledWrapper from './StyledWrapper';
 import FileBody from '../FileBody/index';
+import { prettifyJsonString } from 'utils/common/index';
+import { toastError } from 'utils/common/error';
 
 const RequestBody = ({ item, collection }) => {
   const dispatch = useDispatch();
@@ -34,6 +36,16 @@ const RequestBody = ({ item, collection }) => {
 
   const onRun = () => dispatch(sendRequest(item, collection.uid));
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
+  const onPrettify = () => {
+    if (bodyMode !== 'json' || !body?.json) return;
+
+    try {
+      const prettyBodyJson = prettifyJsonString(body.json);
+      onEdit(prettyBodyJson);
+    } catch (error) {
+      toastError(new Error('Unable to prettify. Invalid JSON format.'));
+    }
+  };
 
   const onScroll = (editor) => {
     dispatch(
@@ -71,6 +83,8 @@ const RequestBody = ({ item, collection }) => {
           onEdit={onEdit}
           onRun={onRun}
           onSave={onSave}
+          onPrettify={bodyMode === 'json' ? onPrettify : undefined}
+          syncValueWhileFocused={bodyMode === 'json'}
           onScroll={onScroll}
           initialScroll={focusedTab?.requestBodyScrollPosition || 0}
           mode={codeMirrorMode[bodyMode]}

--- a/packages/coldbru-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
+++ b/packages/coldbru-app/src/components/RequestPane/WsBody/SingleWSMessage/index.js
@@ -175,6 +175,8 @@ export const SingleWSMessage = ({
           onEdit={onEdit}
           onRun={handleRun}
           onSave={onSave}
+          onPrettify={codeType === 'json' ? onPrettify : undefined}
+          syncValueWhileFocused={codeType === 'json'}
           mode={codemirrorMode[codeType] ?? 'text/plain'}
           enableVariableHighlighting={true}
         />

--- a/packages/coldbru-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
+++ b/packages/coldbru-app/src/components/Sidebar/Collections/Collection/CollectionItem/index.js
@@ -57,6 +57,7 @@ import { openDevtoolsAndSwitchToTerminal } from 'utils/terminal';
 import ActionIcon from 'ui/ActionIcon';
 import MenuDropdown from 'ui/MenuDropdown';
 import { useSidebarAccordion } from 'components/Sidebar/SidebarAccordionContext';
+import { focusSidebarRowByOffset } from '../../utils/keyboardNavigation';
 
 const CollectionItem = ({ item, collectionUid, collectionPathname, searchText }) => {
   const { dropdownContainerRef } = useSidebarAccordion();
@@ -315,8 +316,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
     );
   };
 
-  const handleClick = (event) => {
-    if (event && event.detail != 1) return;
+  const activateItem = () => {
     // scroll to the active tab
     setTimeout(scrollToTheActiveTab, 50);
     const isRequest = isItemARequest(item);
@@ -354,6 +354,11 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
         );
       }
     }
+  };
+
+  const handleClick = (event) => {
+    if (event && event.detail != 1) return;
+    activateItem();
   };
 
   const handleFolderCollapse = (e) => {
@@ -677,6 +682,35 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
 
   // Keyboard shortcuts handler
   const handleKeyDown = (e) => {
+    if (e.key === 'ArrowDown') {
+      const moved = focusSidebarRowByOffset(e.currentTarget, 1);
+
+      if (moved) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+
+      return;
+    }
+
+    if (e.key === 'ArrowUp') {
+      const moved = focusSidebarRowByOffset(e.currentTarget, -1);
+
+      if (moved) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+
+      return;
+    }
+
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      e.stopPropagation();
+      activateItem();
+      return;
+    }
+
     // Detect Mac by checking both metaKey and platform
     const isMac = navigator.userAgent?.includes('Mac') || navigator.platform?.startsWith('Mac');
     const isModifierPressed = isMac ? e.metaKey : e.ctrlKey;
@@ -750,6 +784,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText })
         onBlur={handleBlur}
         onContextMenu={handleContextMenu}
         data-testid="sidebar-collection-item-row"
+        data-sidebar-navigable="true"
       >
         <div className="flex items-center h-full w-full min-w-0">
           {indents && indents.length

--- a/packages/coldbru-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/coldbru-app/src/components/Sidebar/Collections/Collection/index.js
@@ -16,6 +16,8 @@ import {
   IconEdit,
   IconShare,
   IconFoldDown,
+  IconArrowBarToUp,
+  IconArrowBarToDown,
   IconX,
   IconSettings,
   IconTerminal2,
@@ -24,7 +26,7 @@ import {
 } from '@tabler/icons';
 import OpenAPISyncIcon from 'components/Icons/OpenAPISync';
 import { toggleCollection, collapseFullCollection } from 'providers/ReduxStore/slices/collections';
-import { mountCollection, moveCollectionAndPersist, handleCollectionItemDrop, pasteItem, showInFolder, saveCollectionSecurityConfig } from 'providers/ReduxStore/slices/collections/actions';
+import { mountCollection, moveCollectionAndPersist, moveCollectionToPositionAndPersist, handleCollectionItemDrop, pasteItem, showInFolder, saveCollectionSecurityConfig } from 'providers/ReduxStore/slices/collections/actions';
 import { useDispatch, useSelector } from 'react-redux';
 import { addTab, makeTabPermanent } from 'providers/ReduxStore/slices/tabs';
 import toast from 'react-hot-toast';
@@ -216,6 +218,13 @@ const Collection = ({ collection, searchText }) => {
       })
       .catch((err) => {
         toast.error(err ? err.message : 'An error occurred while pasting the item');
+      });
+  };
+
+  const handleMoveCollectionToPosition = (position) => {
+    dispatch(moveCollectionToPositionAndPersist({ collectionUid: collection.uid, position }))
+      .catch((err) => {
+        toast.error(err ? err.message : 'Failed to reorder collection');
       });
   };
 
@@ -414,6 +423,18 @@ const Collection = ({ collection, searchText }) => {
         ensureCollectionIsMounted();
         handleRun();
       }
+    },
+    {
+      id: 'send-to-top',
+      leftSection: IconArrowBarToUp,
+      label: 'Send to Top',
+      onClick: () => handleMoveCollectionToPosition('top')
+    },
+    {
+      id: 'send-to-bottom',
+      leftSection: IconArrowBarToDown,
+      label: 'Send to Bottom',
+      onClick: () => handleMoveCollectionToPosition('bottom')
     },
     {
       id: 'clone',

--- a/packages/coldbru-app/src/components/Sidebar/Collections/Collection/index.js
+++ b/packages/coldbru-app/src/components/Sidebar/Collections/Collection/index.js
@@ -52,6 +52,7 @@ import ActionIcon from 'ui/ActionIcon';
 import MenuDropdown from 'ui/MenuDropdown';
 import { useSidebarAccordion } from 'components/Sidebar/SidebarAccordionContext';
 import { createEmptyStateMenuItems } from 'utils/collections/emptyStateRequest';
+import { focusSidebarRowByOffset } from '../utils/keyboardNavigation';
 
 // Delay before showing empty collection state (ms)
 // This prevents flicker from race condition between loading state and item batch updates
@@ -132,10 +133,7 @@ const Collection = ({ collection, searchText }) => {
     'rotate-90': !collectionIsCollapsed
   });
 
-  const handleClick = (event) => {
-    if (event.detail != 1) return;
-    // Check if the click came from the chevron icon
-    const isChevronClick = event.target.closest('svg')?.classList.contains('chevron-icon');
+  const activateCollection = ({ openSettings = true, isChevronClick = false } = {}) => {
     setTimeout(scrollToTheActiveTab, 50);
 
     ensureCollectionIsMounted();
@@ -150,7 +148,7 @@ const Collection = ({ collection, searchText }) => {
       }
     }
 
-    if (!isChevronClick) {
+    if (openSettings && !isChevronClick) {
       dispatch(
         addTab({
           uid: collection.uid,
@@ -159,6 +157,14 @@ const Collection = ({ collection, searchText }) => {
         })
       );
     }
+  };
+
+  const handleClick = (event) => {
+    if (event.detail != 1) return;
+
+    // Check if the click came from the chevron icon
+    const isChevronClick = event.target.closest('svg')?.classList.contains('chevron-icon');
+    activateCollection({ isChevronClick });
   };
 
   const handleDoubleClick = (_event) => {
@@ -230,6 +236,35 @@ const Collection = ({ collection, searchText }) => {
 
   // Keyboard shortcuts handler for collection
   const handleKeyDown = (e) => {
+    if (e.key === 'ArrowDown') {
+      const moved = focusSidebarRowByOffset(e.currentTarget, 1);
+
+      if (moved) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+
+      return;
+    }
+
+    if (e.key === 'ArrowUp') {
+      const moved = focusSidebarRowByOffset(e.currentTarget, -1);
+
+      if (moved) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+
+      return;
+    }
+
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      e.stopPropagation();
+      activateCollection();
+      return;
+    }
+
     // Detect Mac by checking both metaKey and platform
     const isMac = navigator.userAgent?.includes('Mac') || navigator.platform?.startsWith('Mac');
     const isModifierPressed = isMac ? e.metaKey : e.ctrlKey;
@@ -559,6 +594,7 @@ const Collection = ({ collection, searchText }) => {
         onFocus={handleFocus}
         onBlur={handleBlur}
         data-testid="sidebar-collection-row"
+        data-sidebar-navigable="true"
       >
         <div
           className="flex flex-grow items-center overflow-hidden min-w-0"

--- a/packages/coldbru-app/src/components/Sidebar/Collections/CollectionSearch/index.js
+++ b/packages/coldbru-app/src/components/Sidebar/Collections/CollectionSearch/index.js
@@ -1,7 +1,29 @@
+import React from 'react';
 import { IconSearch, IconX } from '@tabler/icons';
 import StyledWrapper from './StyledWrapper';
+import { focusSidebarEdgeRow } from '../utils/keyboardNavigation';
 
 const CollectionSearch = ({ searchText, setSearchText }) => {
+  const handleKeyDown = (event) => {
+    if (event.key === 'ArrowDown') {
+      const moved = focusSidebarEdgeRow(1);
+
+      if (moved) {
+        event.preventDefault();
+      }
+
+      return;
+    }
+
+    if (event.key === 'ArrowUp') {
+      const moved = focusSidebarEdgeRow(-1);
+
+      if (moved) {
+        event.preventDefault();
+      }
+    }
+  };
+
   return (
     <StyledWrapper>
       <IconSearch size={14} strokeWidth={1.5} className="search-icon" />
@@ -17,6 +39,7 @@ const CollectionSearch = ({ searchText, setSearchText }) => {
         spellCheck="false"
         value={searchText}
         onChange={(e) => setSearchText(e.target.value.toLowerCase())}
+        onKeyDown={handleKeyDown}
       />
       {searchText !== '' && (
         <div className="clear-icon" onClick={() => setSearchText('')}>

--- a/packages/coldbru-app/src/components/Sidebar/Collections/CollectionSearch/index.spec.js
+++ b/packages/coldbru-app/src/components/Sidebar/Collections/CollectionSearch/index.spec.js
@@ -1,0 +1,74 @@
+require('@testing-library/jest-dom');
+
+const React = require('react');
+const { fireEvent, render, screen } = require('@testing-library/react');
+
+jest.mock('./StyledWrapper', () => ({ children }) => {
+  const mockReact = require('react');
+  return mockReact.createElement('div', null, children);
+});
+
+const CollectionSearch = require('./index').default;
+
+const createSidebarRow = (label) => {
+  const row = document.createElement('button');
+  row.type = 'button';
+  row.textContent = label;
+  row.setAttribute('data-sidebar-navigable', 'true');
+  row.scrollIntoView = jest.fn();
+
+  document.body.appendChild(row);
+
+  return row;
+};
+
+describe('CollectionSearch keyboard navigation', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('moves focus to first visible sidebar row with ArrowDown', () => {
+    const setSearchText = jest.fn();
+    const firstRow = createSidebarRow('Collection A');
+    createSidebarRow('Collection B');
+
+    render(React.createElement(CollectionSearch, {
+      searchText: '',
+      setSearchText
+    }));
+
+    fireEvent.keyDown(screen.getByPlaceholderText('Search requests...'), { key: 'ArrowDown' });
+
+    expect(firstRow).toHaveFocus();
+  });
+
+  it('moves focus to last visible sidebar row with ArrowUp', () => {
+    const setSearchText = jest.fn();
+    createSidebarRow('Collection A');
+    const lastRow = createSidebarRow('Collection B');
+
+    render(React.createElement(CollectionSearch, {
+      searchText: '',
+      setSearchText
+    }));
+
+    fireEvent.keyDown(screen.getByPlaceholderText('Search requests...'), { key: 'ArrowUp' });
+
+    expect(lastRow).toHaveFocus();
+  });
+
+  it('keeps typing behavior unchanged', () => {
+    const setSearchText = jest.fn();
+
+    render(React.createElement(CollectionSearch, {
+      searchText: '',
+      setSearchText
+    }));
+
+    fireEvent.change(screen.getByPlaceholderText('Search requests...'), {
+      target: { value: 'Billing' }
+    });
+
+    expect(setSearchText).toHaveBeenCalledWith('billing');
+  });
+});

--- a/packages/coldbru-app/src/components/Sidebar/Collections/utils/keyboardNavigation.js
+++ b/packages/coldbru-app/src/components/Sidebar/Collections/utils/keyboardNavigation.js
@@ -1,0 +1,55 @@
+export const SIDEBAR_NAVIGABLE_SELECTOR = '[data-sidebar-navigable="true"]';
+
+const scrollRowIntoView = (row) => {
+  row?.scrollIntoView?.({
+    block: 'nearest',
+    inline: 'nearest'
+  });
+};
+
+export const getSidebarNavigableRows = (root = document) => {
+  return Array.from(root.querySelectorAll(SIDEBAR_NAVIGABLE_SELECTOR));
+};
+
+export const focusSidebarRowByOffset = (currentRow, direction, root = document) => {
+  const rows = getSidebarNavigableRows(root);
+
+  if (!rows.length) {
+    return false;
+  }
+
+  const currentIndex = rows.indexOf(currentRow);
+  const fallbackIndex = direction > 0 ? 0 : rows.length - 1;
+  const nextIndex = currentIndex < 0
+    ? fallbackIndex
+    : (currentIndex + direction + rows.length) % rows.length;
+  const nextRow = rows[nextIndex];
+
+  if (!nextRow) {
+    return false;
+  }
+
+  nextRow.focus();
+  scrollRowIntoView(nextRow);
+
+  return true;
+};
+
+export const focusSidebarEdgeRow = (direction, root = document) => {
+  const rows = getSidebarNavigableRows(root);
+
+  if (!rows.length) {
+    return false;
+  }
+
+  const targetRow = direction > 0 ? rows[0] : rows[rows.length - 1];
+
+  if (!targetRow) {
+    return false;
+  }
+
+  targetRow.focus();
+  scrollRowIntoView(targetRow);
+
+  return true;
+};

--- a/packages/coldbru-app/src/components/Sidebar/Collections/utils/keyboardNavigation.spec.js
+++ b/packages/coldbru-app/src/components/Sidebar/Collections/utils/keyboardNavigation.spec.js
@@ -1,0 +1,78 @@
+require('@testing-library/jest-dom');
+
+const {
+  SIDEBAR_NAVIGABLE_SELECTOR,
+  focusSidebarRowByOffset,
+  focusSidebarEdgeRow,
+  getSidebarNavigableRows
+} = require('./keyboardNavigation');
+
+const createRow = (label) => {
+  const row = document.createElement('button');
+  row.type = 'button';
+  row.textContent = label;
+  row.setAttribute('data-sidebar-navigable', 'true');
+  row.scrollIntoView = jest.fn();
+
+  return row;
+};
+
+describe('sidebar keyboard navigation helpers', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('returns all navigable sidebar rows in DOM order', () => {
+    const firstRow = createRow('First');
+    const secondRow = createRow('Second');
+
+    document.body.append(firstRow, secondRow);
+
+    expect(getSidebarNavigableRows()).toEqual([firstRow, secondRow]);
+    expect(document.querySelectorAll(SIDEBAR_NAVIGABLE_SELECTOR)).toHaveLength(2);
+  });
+
+  it('moves focus to next row and wraps around', () => {
+    const firstRow = createRow('First');
+    const secondRow = createRow('Second');
+
+    document.body.append(firstRow, secondRow);
+    firstRow.focus();
+
+    expect(focusSidebarRowByOffset(firstRow, 1)).toBe(true);
+    expect(secondRow).toHaveFocus();
+
+    expect(focusSidebarRowByOffset(secondRow, 1)).toBe(true);
+    expect(firstRow).toHaveFocus();
+  });
+
+  it('moves focus to previous row from current row', () => {
+    const firstRow = createRow('First');
+    const secondRow = createRow('Second');
+    const thirdRow = createRow('Third');
+
+    document.body.append(firstRow, secondRow, thirdRow);
+    secondRow.focus();
+
+    expect(focusSidebarRowByOffset(secondRow, -1)).toBe(true);
+    expect(firstRow).toHaveFocus();
+  });
+
+  it('focuses first or last row from search input handoff', () => {
+    const firstRow = createRow('First');
+    const secondRow = createRow('Second');
+
+    document.body.append(firstRow, secondRow);
+
+    expect(focusSidebarEdgeRow(1)).toBe(true);
+    expect(firstRow).toHaveFocus();
+
+    expect(focusSidebarEdgeRow(-1)).toBe(true);
+    expect(secondRow).toHaveFocus();
+  });
+
+  it('returns false when no rows exist', () => {
+    expect(focusSidebarRowByOffset(null, 1)).toBe(false);
+    expect(focusSidebarEdgeRow(1)).toBe(false);
+  });
+});

--- a/packages/coldbru-app/src/providers/App/ConfirmAppClose/SaveRequestsModal.js
+++ b/packages/coldbru-app/src/providers/App/ConfirmAppClose/SaveRequestsModal.js
@@ -101,7 +101,9 @@ const SaveRequestsModal = ({ onClose }) => {
 
   useEffect(() => {
     if (totalDraftsCount === 0) {
-      return dispatch(completeQuitFlow());
+      console.log('[quit-flow] No unsaved drafts — completing quit flow');
+      dispatch(completeQuitFlow());
+      return;
     }
   }, [totalDraftsCount, dispatch]);
 

--- a/packages/coldbru-app/src/providers/App/ConfirmAppClose/index.js
+++ b/packages/coldbru-app/src/providers/App/ConfirmAppClose/index.js
@@ -14,6 +14,7 @@ const ConfirmAppClose = () => {
     }
 
     const clearListener = ipcRenderer.on('main:start-quit-flow', () => {
+      console.log('[quit-flow] Renderer received start-quit-flow');
       setShowConfirmClose(true);
     });
 

--- a/packages/coldbru-app/src/providers/Hotkeys/index.js
+++ b/packages/coldbru-app/src/providers/Hotkeys/index.js
@@ -8,6 +8,7 @@ import NewRequest from 'components/Sidebar/NewRequest';
 import NetworkError from 'components/ResponsePane/NetworkError';
 import GlobalSearchModal from 'components/GlobalSearchModal';
 import ImportCollection from 'components/Sidebar/ImportCollection';
+import CommandPaletteModal from 'components/CommandPaletteModal';
 
 import store from 'providers/ReduxStore/index';
 import {
@@ -29,6 +30,7 @@ export const HotkeysContext = createContext(null);
 
 // List of all actions that are bound in this provider
 const BOUND_ACTIONS = [
+  'commandPalette',
   'save',
   'sendRequest',
   'editEnvironment',
@@ -117,6 +119,11 @@ function unbindAllHotkeys(userKeyBindings) {
  */
 function bindAllHotkeys(userKeyBindings) {
   const { dispatch, getState } = store;
+
+  // SAVE
+  bindHotkey('commandPalette', () => {
+    window.dispatchEvent(new CustomEvent('command-palette-open'));
+  }, userKeyBindings);
 
   // SAVE
   bindHotkey('save', () => {
@@ -338,6 +345,7 @@ export const HotkeysProvider = (props) => {
   const [showNewRequestModal, setShowNewRequestModal] = useState(false);
   const [showGlobalSearchModal, setShowGlobalSearchModal] = useState(false);
   const [showImportCollectionModal, setShowImportCollectionModal] = useState(false);
+  const [showCommandPaletteModal, setShowCommandPaletteModal] = useState(false);
 
   // Keep a ref to the previous userKeyBindings so we can unbind old combos
   const prevKeyBindingsRef = useRef(undefined);
@@ -375,15 +383,18 @@ export const HotkeysProvider = (props) => {
     const openNewRequest = () => setShowNewRequestModal(true);
     const openGlobalSearch = () => setShowGlobalSearchModal(true);
     const openImportCollection = () => setShowImportCollectionModal(true);
+    const openCommandPalette = () => setShowCommandPaletteModal(true);
 
     window.addEventListener('new-request-open', openNewRequest);
     window.addEventListener('global-search-open', openGlobalSearch);
     window.addEventListener('import-collection-open', openImportCollection);
+    window.addEventListener('command-palette-open', openCommandPalette);
 
     return () => {
       window.removeEventListener('new-request-open', openNewRequest);
       window.removeEventListener('global-search-open', openGlobalSearch);
       window.removeEventListener('import-collection-open', openImportCollection);
+      window.removeEventListener('command-palette-open', openCommandPalette);
     };
   }, []);
 
@@ -397,6 +408,9 @@ export const HotkeysProvider = (props) => {
       )}
       {showImportCollectionModal && (
         <ImportCollection onClose={() => setShowImportCollectionModal(false)} />
+      )}
+      {showCommandPaletteModal && (
+        <CommandPaletteModal isOpen={showCommandPaletteModal} onClose={() => setShowCommandPaletteModal(false)} />
       )}
       <div>{props.children}</div>
     </HotkeysContext.Provider>

--- a/packages/coldbru-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/coldbru-app/src/providers/Hotkeys/keyMappings.js
@@ -39,6 +39,7 @@ export const DEFAULT_KEY_BINDINGS = {
   zoomIn: { mac: 'command+bind+=', windows: 'ctrl+bind+=', name: 'Zoom In' },
   zoomOut: { mac: 'command+bind+-', windows: 'ctrl+bind+-', name: 'Zoom Out' },
   resetZoom: { mac: 'command+bind+0', windows: 'ctrl+bind+0', name: 'Reset Zoom' },
+  formatJson: { mac: 'shift+bind+alt+bind+f', windows: 'shift+bind+alt+bind+f', name: 'Format JSON' },
   cloneItem: { mac: 'command+bind+d', windows: 'ctrl+bind+d', name: 'Clone Item' },
   copyItem: { mac: 'command+bind+c', windows: 'ctrl+bind+c', name: 'Copy Item' },
   pasteItem: { mac: 'command+bind+v', windows: 'ctrl+bind+v', name: 'Paste Item' },

--- a/packages/coldbru-app/src/providers/Hotkeys/keyMappings.js
+++ b/packages/coldbru-app/src/providers/Hotkeys/keyMappings.js
@@ -1,4 +1,5 @@
 export const DEFAULT_KEY_BINDINGS = {
+  commandPalette: { mac: 'command+bind+shift+bind+p', windows: 'ctrl+bind+shift+bind+p', name: 'Command Palette' },
   save: { mac: 'command+bind+s', windows: 'ctrl+bind+s', name: 'Save' },
   sendRequest: { mac: 'command+bind+enter', windows: 'ctrl+bind+enter', name: 'Send Request' },
   editEnvironment: { mac: 'command+bind+e', windows: 'ctrl+bind+e', name: 'Edit Environment' },

--- a/packages/coldbru-app/src/providers/Hotkeys/keyMappings.spec.js
+++ b/packages/coldbru-app/src/providers/Hotkeys/keyMappings.spec.js
@@ -1,0 +1,16 @@
+const { describe, it, expect } = require('@jest/globals');
+const { DEFAULT_KEY_BINDINGS, getKeyBindingsForActionAllOS } = require('./keyMappings');
+
+describe('keyMappings', () => {
+  it('uses shift alt f as default format json shortcut on mac and windows', () => {
+    expect(DEFAULT_KEY_BINDINGS.formatJson).toEqual({
+      mac: 'shift+bind+alt+bind+f',
+      windows: 'shift+bind+alt+bind+f',
+      name: 'Format JSON'
+    });
+  });
+
+  it('returns format json shortcuts for all supported operating systems', () => {
+    expect(getKeyBindingsForActionAllOS('formatJson')).toEqual(['shift+alt+f', 'shift+alt+f']);
+  });
+});

--- a/packages/coldbru-app/src/providers/ReduxStore/slices/collections/actions.js
+++ b/packages/coldbru-app/src/providers/ReduxStore/slices/collections/actions.js
@@ -37,6 +37,7 @@ import {
   sortCollections as _sortCollections,
   updateCollectionMountStatus,
   moveCollection,
+  moveCollectionToPosition,
   workspaceEnvUpdateEvent,
   requestCancelled,
   resetRunResults,
@@ -2777,6 +2778,46 @@ export const moveCollectionAndPersist
         .invoke('renderer:reorder-workspace-collections', activeWorkspace.pathname, collectionPaths)
         .then(() => {
           dispatch(moveCollection({ draggedItem, targetItem }));
+        })
+        .catch((err) => {
+          console.error('Failed to reorder workspace collections', err);
+          return Promise.reject(err);
+        });
+    };
+
+export const moveCollectionToPositionAndPersist
+  = ({ collectionUid, position }) =>
+    (dispatch, getState) => {
+      const state = getState();
+      const activeWorkspace = state.workspaces.workspaces.find(
+        (w) => w.uid === state.workspaces.activeWorkspaceUid
+      );
+      if (!activeWorkspace?.pathname || !activeWorkspace.collections?.length) {
+        return Promise.resolve();
+      }
+
+      const workspacePathSet = new Set(
+        activeWorkspace.collections.map((wc) => normalizePath(wc.path))
+      );
+      const collectionsInWorkspace = state.collections.collections
+        .filter((c) => workspacePathSet.has(normalizePath(c.pathname)));
+      const collectionToMove = collectionsInWorkspace.find((c) => c.uid === collectionUid);
+      if (!collectionToMove) {
+        return Promise.resolve();
+      }
+
+      const reordered = collectionsInWorkspace.filter((c) => c.uid !== collectionUid);
+      if (position === 'top') {
+        reordered.unshift(collectionToMove);
+      } else {
+        reordered.push(collectionToMove);
+      }
+      const collectionPaths = reordered.map((c) => c.pathname);
+
+      return window.ipcRenderer
+        .invoke('renderer:reorder-workspace-collections', activeWorkspace.pathname, collectionPaths)
+        .then(() => {
+          dispatch(moveCollectionToPosition({ collectionUid, position }));
         })
         .catch((err) => {
           console.error('Failed to reorder workspace collections', err);

--- a/packages/coldbru-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/coldbru-app/src/providers/ReduxStore/slices/collections/index.js
@@ -274,6 +274,20 @@ export const collectionsSlice = createSlice({
       const targetItemIndex = state.collections.findIndex((i) => i.uid === targetItem.uid); // Find target item
       state.collections.splice(targetItemIndex, 0, draggedItem); // Insert dragged-item above target-item
     },
+    moveCollectionToPosition: (state, action) => {
+      const { collectionUid, position } = action.payload;
+      const collectionIndex = state.collections.findIndex((i) => i.uid === collectionUid);
+      if (collectionIndex === -1) {
+        return;
+      }
+
+      const [collection] = state.collections.splice(collectionIndex, 1);
+      if (position === 'top') {
+        state.collections.unshift(collection);
+      } else {
+        state.collections.push(collection);
+      }
+    },
     updateLastAction: (state, action) => {
       const { collectionUid, lastAction } = action.payload;
       const collection = findCollectionByUid(state.collections, collectionUid);
@@ -3695,6 +3709,7 @@ export const {
   updateRequestDocs,
   updateFolderDocs,
   moveCollection,
+  moveCollectionToPosition,
   streamDataReceived,
   collectionAddOauth2CredentialsByUrl,
   collectionClearOauth2CredentialsByUrlAndCredentialsId,

--- a/packages/coldbru-app/src/utils/codemirror/shortcuts.js
+++ b/packages/coldbru-app/src/utils/codemirror/shortcuts.js
@@ -72,6 +72,17 @@ const KEYBINDING_ACTIONS = [
       store.dispatch(toggleSidebarCollapse());
       return true;
     }
+  },
+  {
+    actionName: 'formatJson',
+    handler: (context) => {
+      if (context?.props?.onPrettify) {
+        context.props.onPrettify();
+        return true;
+      }
+
+      return false;
+    }
   }
 ];
 

--- a/packages/coldbru-app/src/utils/codemirror/shortcuts.spec.js
+++ b/packages/coldbru-app/src/utils/codemirror/shortcuts.spec.js
@@ -1,4 +1,4 @@
-const { describe, it, expect, jest, beforeEach, afterEach } = require('@jest/globals');
+const { describe, it, expect, beforeEach, afterEach } = require('@jest/globals');
 
 jest.mock('codemirror', () => ({
   Pass: 'CodeMirror.Pass'
@@ -6,6 +6,16 @@ jest.mock('codemirror', () => ({
 
 jest.mock('providers/Hotkeys/keyMappings', () => ({
   getKeyBindingsForActionAllOS: jest.fn(() => [])
+}));
+
+jest.mock('providers/ReduxStore/index', () => ({
+  dispatch: jest.fn(),
+  getState: jest.fn(() => ({
+    app: {
+      preferences: {}
+    }
+  })),
+  subscribe: jest.fn()
 }));
 
 jest.mock('providers/ReduxStore/slices/tabs', () => ({
@@ -18,7 +28,8 @@ jest.mock('providers/ReduxStore/slices/app', () => ({
   toggleSidebarCollapse: jest.fn(() => ({ type: 'app/toggleSidebarCollapse' }))
 }));
 
-import { setupShortcuts } from './shortcuts';
+const { setupShortcuts } = require('./shortcuts');
+const { getKeyBindingsForActionAllOS } = require('providers/Hotkeys/keyMappings');
 
 describe('setupShortcuts', () => {
   let editor;
@@ -91,5 +102,26 @@ describe('setupShortcuts', () => {
 
     expect(editor.removeKeyMap).toHaveBeenCalledTimes(1);
     expect(editor.addKeyMap).toHaveBeenCalledTimes(2);
+  });
+
+  it('calls onPrettify when format json shortcut fires', () => {
+    const onPrettify = jest.fn();
+    getKeyBindingsForActionAllOS.mockImplementation((action) => {
+      if (action === 'formatJson') {
+        return ['shift+alt+f'];
+      }
+
+      return [];
+    });
+
+    setupShortcuts(editor, { props: { onPrettify } }, mockStore);
+
+    const keyMap = editor.addKeyMap.mock.calls[0][0];
+    expect(typeof keyMap['Shift-Alt-F']).toBe('function');
+
+    const handled = keyMap['Shift-Alt-F']();
+
+    expect(handled).toBe(true);
+    expect(onPrettify).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/coldbru-electron/src/index.js
+++ b/packages/coldbru-electron/src/index.js
@@ -395,10 +395,28 @@ app.on('ready', async () => {
     mainWindow.webContents.send('main:leave-full-screen');
   });
 
+  let isQuitting = false;
   mainWindow.on('close', (e) => {
+    if (isQuitting) return;
+    isQuitting = true;
     e.preventDefault();
     terminalManager.cleanup(mainWindow.webContents);
+
+    // Flush cookies before quit since app.exit() skips before-quit
+    try { cookiesStore.saveCookieJar(true); } catch (err) { console.warn('Failed to flush cookies on quit', err); }
+    systemMonitor.stop();
+    try { terminalManager.killAll(); } catch (err) { console.error('Failed to kill all terminals on quit', err); }
+    if (useSingleInstance && gotTheLock) { app.releaseSingleInstanceLock(); }
+
     ipcMain.emit('main:start-quit-flow');
+
+    // Safety net: force quit if the renderer never responds
+    setTimeout(() => {
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        console.warn('Quit flow timed out — forcing quit');
+        process.exit(0);
+      }
+    }, 5000);
   });
 
   mainWindow.webContents.on('will-redirect', (event, url) => {

--- a/packages/coldbru-electron/src/ipc/collection.js
+++ b/packages/coldbru-electron/src/ipc/collection.js
@@ -2444,11 +2444,13 @@ const registerMainEventHandlers = (mainWindow, watcher) => {
 
   // The app listen for this event and allows the user to save unsaved requests before closing the app
   ipcMain.on('main:start-quit-flow', () => {
+    console.log('[quit-flow] Sending start-quit-flow to renderer');
     mainWindow.webContents.send('main:start-quit-flow');
   });
 
   ipcMain.handle('main:complete-quit-flow', () => {
-    mainWindow.destroy();
+    console.log('[quit-flow] Renderer completed quit flow — quitting app');
+    process.exit(0);
   });
 
   ipcMain.handle('main:force-quit', () => {


### PR DESCRIPTION
### Description

- Add a real `Cmd/Ctrl+Shift+P` command palette for fast app actions.
- Let the palette open the existing environment selector directly, with separate collection and global commands.
- Improve environment picker search autofocus and keyboard navigation, with coverage added for the new flow.
- Update related navigation, hotkey, and editor shortcuts across the app.

#### Contribution Checklist:

- [x] **I've used AI significantly to create this pull request**
- [ ] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [ ] **I have read the [contribution guidelines](https://github.com/nicandcranny/coldbru/blob/main/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.
