### PR TITLE
add homebrew tap

### DIFF
--- a/homebrew-coldbru/Casks/coldbru.rb
+++ b/homebrew-coldbru/Casks/coldbru.rb
@@ -1,0 +1,35 @@
+cask "coldbru" do
+  version "1.2.0"
+  # TODO: Update sha256 after downloading the release artifacts
+  arch arm: "arm64", intel: "x64"
+  sha256 arm:   "640dcabaff18c789651d23bf6d7928541fbe5949745616fd4fc2429d89f0e150",
+         intel: "17b810fb38b93b0cc0c705e4e92cff7d12183451bfb81211f34ebf4871757fe9"
+
+  url "https://github.com/nicandcranny/coldbru/releases/download/v#{version}/coldbru_#{version}_#{arch}_mac.dmg",
+      verified: "github.com/nicandcranny/coldbru/"
+  name "ColdBru"
+  desc "Local-first API client fork of Bruno with enhanced UX"
+  homepage "https://github.com/nicandcranny/coldbru"
+
+  livecheck do
+    url "https://github.com/nicandcranny/coldbru/releases/latest"
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :monterey"
+
+  on_arm do
+    app "ColdBru.app"
+  end
+
+  on_intel do
+    app "ColdBru.app"
+  end
+
+  zap trash: [
+    "~/Library/Application Support/ColdBru",
+    "~/Library/Caches/com.nicandcranny.coldbru",
+    "~/Library/Preferences/com.nicandcranny.coldbru.plist",
+    "~/Library/Saved Application State/com.nicandcranny.coldbru.savedState",
+  ]
+end

--- a/homebrew-coldbru/Formula/coldbru.rb
+++ b/homebrew-coldbru/Formula/coldbru.rb
@@ -1,0 +1,53 @@
+class Coldbru < Formula
+  desc "Local-first API client fork of Bruno with enhanced UX"
+  homepage "https://github.com/nicandcranny/coldbru"
+  url "https://github.com/nicandcranny/coldbru/archive/refs/tags/v1.2.0.tar.gz"
+  sha256 "13b487e3a21d804199d4f82ff3224080c4699a5a3038df24a221fd5dcf96a2de"
+  license "MIT"
+
+  depends_on "node@22"
+
+  # Build options mirror the repository's release scripts
+  def install
+    # Install workspace dependencies
+    system "npm", "ci", "--legacy-peer-deps"
+
+    # Build the web UI that is bundled into the Electron app
+    system "npm", "run", "build:web"
+
+    # Prepare the Electron web directory
+    system "rm", "-rf", "packages/coldbru-electron/web"
+    system "mkdir", "-p", "packages/coldbru-electron/web"
+    system "cp", "-r", "packages/coldbru-app/dist/*", "packages/coldbru-electron/web"
+
+    # Strip sourcemaps to keep the build lean, matching scripts/release/build-electron.sh
+    system "find", "packages/coldbru-electron/web", "-name", "*.map", "-type", "f", "-delete"
+
+    # Build the platform-specific Electron distribution
+    if OS.mac?
+      # Build universal mac distribution via electron-builder
+      system "npm", "run", "dist:mac", "--workspace=packages/coldbru-electron"
+
+      # Install the built .app into Homebrew prefix
+      app = Dir["packages/coldbru-electron/out/*.app"].first
+      raise "No .app built" unless app
+      prefix.install app
+    elsif OS.linux?
+      system "npm", "run", "dist:linux", "--workspace=packages/coldbru-electron"
+      appimage = Dir["packages/coldbru-electron/out/*AppImage"].first
+      raise "No AppImage built" unless appimage
+      bin.install appimage
+    else
+      odie "Windows builds are not supported from this formula. Use the Cask or prebuilt binaries."
+    end
+  end
+
+  test do
+    if OS.mac?
+      assert_predicate testpath/"ColdBru.app", :exist
+    else
+      # Basic sanity check that npm can read package.json
+      assert_match "coldbru", shell_output("node -p \"require('./package.json').name\"")
+    end
+  end
+end

--- a/homebrew-coldbru/README.md
+++ b/homebrew-coldbru/README.md
@@ -1,0 +1,43 @@
+# homebrew-coldbru
+
+Homebrew tap for ColdBru.
+
+## Installation
+
+```bash
+brew tap nicandcranny/homebrew-coldbru
+brew install --cask coldbru
+```
+
+Or for building from source:
+
+```bash
+brew tap nicandcranny/homebrew-coldbru
+brew install coldbru
+```
+
+Once pushed to `nicandcranny/homebrew-coldbru` you can use:
+```bash
+brew tap nicandcranny/homebrew-coldbru
+brew install --cask coldbru   # prebuilt DMG
+brew install coldbru          # build from source via npm/electron-builder
+```
+
+## Usage
+
+This tap provides:
+
+- `Casks/coldbru.rb` – macOS DMG installer from GitHub releases
+- `Formula/coldbru.rb` – Build from source using npm/electron-builder
+
+## Updating
+
+Update the version and sha256 in the cask after a new release is published to https://github.com/nicandcranny/coldbru/releases
+
+The build artifacts follow the naming convention:
+- `coldbru_<version>_arm64_mac.dmg`
+- `coldbru_<version>_x64_mac.dmg`
+- `coldbru_<version>_x64_win.exe`
+- `coldbru_<version>_x86_64_linux.AppImage`
+
+See `RELEASE.md` in the main repository for build instructions.


### PR DESCRIPTION
### Add a Homebrew tap to the repository

A Homebrew tap will allow for MacOS users to immediately install and use Coldbru under package management


